### PR TITLE
fix(deps): revert Helidon to 2.6.14 — the 2→4 bump never compiled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <service.name>Whydah-HelidonProvider</service.name>
     <whydah-java-sdk-version>3.1.13</whydah-java-sdk-version>
     <additionalparam>-Xdoclint:none</additionalparam>
-    <helidon-version>4.5.1</helidon-version>
+    <helidon-version>2.6.14</helidon-version>
     <jdk.version>11</jdk.version>
   </properties>
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>cantara/Cantara-Renovate-Config"
+  ],
+  "packageRules": [
+    {
+      "description": "Helidon 4 is a breaking rewrite (SynchronousProvider, io.helidon.metrics.RegistryFactory, MP-metrics Meter/Tag are all gone). The code targets Helidon 2.x, so a major bump does not compile until it is migrated by hand. Keep Renovate from proposing/merging Helidon majors; minor+patch within the current major still flow. Remove this rule only together with the Helidon 4 code migration.",
+      "matchPackagePatterns": ["^io\\.helidon"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
The last release (0.4.28) built on Helidon **2.6.14**. `helidon-version` was then walked **2.6.14 → 4.5.0 → 4.5.1** (#418, #433) without migrating the code, and Helidon 4 removed every API this module uses (`RegistryFactory`, `SynchronousProvider`, MP-metrics `Meter`/`Tag`/`MetricRegistry.Type`). So `main` has not compiled since #418 and the release job fails at `mvn compile`.

This reverts to **2.6.14** (known-good) to unblock releases, and adds a Renovate rule disabling Helidon **majors** so the un-migratable bump isn't proposed again (minor/patch within 2.x still flow). Moving to Helidon 4 is a real code migration; drop that rule when it's done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)